### PR TITLE
structure/alien/egg optimizations

### DIFF
--- a/code/game/objects/structures/alien/alien egg.dm
+++ b/code/game/objects/structures/alien/alien egg.dm
@@ -29,9 +29,9 @@
 /obj/structure/alien/egg/process()
 	progress++
 	if(progress >= MAX_PROGRESS)
-		for(var/mob/observer/dead/O)
+		for(var/mob/observer/dead/O in observer_mob_list)
 			if(O.client)
-				to_chat(O, "<span class='notice'>An alien is ready to hatch! (<a href='byond://?src=\ref[src];spawn=1'>spawn</a>)</span>")
+				to_chat(O, "<span class='notice'>An alien is ready to hatch at [get_area(src.loc)]! (<a href='byond://?src=\ref[src];spawn=1'>spawn</a>)</span>")
 		STOP_PROCESSING(SSobj, src)
 		update_icon()
 
@@ -55,7 +55,7 @@
 		return
 
 	// Check for bans properly.
-	if(jobban_isbanned(user, MODE_XENOMORPH))
+	if(jobban_isbanned(user, "Xenomorph"))
 		to_chat(user, "<span class='danger'>You are banned from playing a Xenomorph.</span>")
 		return
 


### PR DESCRIPTION
Big thank you to Jon for helping with this.

- Fixes jobban check, so people that are banned from xenomorph cannot spawn in eggs.
- Optimizes ghost check for sending messages, so it doesn't try to ping things that no longer exist.
- Readds area check for 'ready to spawn' chat notification, so people can find it if they want.