### PR TITLE
Fixes Xenomorph Corrosive acid, adds ALOT of acid immunities  to important stuff

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -16,7 +16,8 @@ Pipelines + Other Objects -> Pipe network
 	power_channel = ENVIRON
 	var/nodealert = 0
 	var/power_rating //the maximum amount of power the machine can use to do work, affects how powerful the machine is, in Watts
-
+	
+	unacidable = TRUE
 	layer = ATMOS_LAYER
 	plane = PLATING_PLANE
 

--- a/code/ATMOSPHERICS/components/binary_devices/circulator.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/circulator.dm
@@ -6,6 +6,7 @@
 	icon = 'icons/obj/power.dmi'
 	icon_state = "circ-unassembled"
 	anchored = FALSE
+	unacidable = TRUE
 	pipe_flags = PIPING_DEFAULT_LAYER_ONLY|PIPING_ONE_PER_TURF
 
 	var/kinetic_efficiency = 0.04 //combined kinetic and kinetic-to-electric efficiency

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -5,6 +5,7 @@
 	icon_state = "table2-idle"
 	density = TRUE
 	anchored = TRUE
+	unacidable = TRUE
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 1
 	active_power_usage = 5

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -6,6 +6,7 @@
 	var/obj/machinery/sleeper/sleeper
 	anchored = TRUE //About time someone fixed this.
 	density = TRUE //VOREStation Edit - Big console
+	unacidable = TRUE
 	dir = 8
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 40
@@ -89,6 +90,7 @@
 	icon_state = "sleeper_0"
 	density = TRUE
 	anchored = TRUE
+	unacidable = TRUE
 	circuit = /obj/item/weapon/circuitboard/sleeper
 	var/mob/living/carbon/human/occupant = null
 	var/list/available_chemicals = list()

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -8,6 +8,7 @@
 	icon_state = "body_scanner_0"
 	density = TRUE
 	anchored = TRUE
+	unacidable = TRUE
 	circuit = /obj/item/weapon/circuitboard/body_scanner
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 60
@@ -547,6 +548,7 @@
 	dir = 8
 	density = FALSE
 	anchored = TRUE
+	unacidable = TRUE
 	circuit = /obj/item/weapon/circuitboard/scanner_console
 	var/printing = null
 

--- a/code/game/machinery/air_alarm.dm
+++ b/code/game/machinery/air_alarm.dm
@@ -32,6 +32,7 @@
 	layer = ABOVE_WINDOW_LAYER
 	vis_flags = VIS_HIDE // They have an emissive that looks bad in openspace due to their wall-mounted nature
 	anchored = TRUE
+	unacidable = TRUE
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 80
 	active_power_usage = 1000 //For heating/cooling rooms. 1000 joules equates to about 1 degree every 2 seconds for a single tile of air.

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -1,6 +1,7 @@
 /obj/structure/AIcore
 	density = TRUE
 	anchored = FALSE
+	unacidable = TRUE
 	name = "\improper AI core"
 	icon = 'icons/mob/AI.dmi'
 	icon_state = "0"

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -4,6 +4,7 @@
 	icon_state = "computer"
 	density = TRUE
 	anchored = TRUE
+	unacidable = TRUE
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 300
 	active_power_usage = 300

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -194,6 +194,7 @@
 	icon_state = "cryopod_0" //VOREStation Edit - New Icon
 	density = TRUE
 	anchored = TRUE
+	unacidable = TRUE
 	dir = WEST
 
 	var/base_icon_state = "cryopod_0" //VOREStation Edit - New Icon

--- a/code/game/machinery/fire_alarm.dm
+++ b/code/game/machinery/fire_alarm.dm
@@ -15,6 +15,7 @@ FIRE ALARM
 	var/timing = 0.0
 	var/lockdownbyai = 0
 	anchored = TRUE
+	unacidable = TRUE
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 2
 	active_power_usage = 6

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -5,6 +5,7 @@
 	icon_state = "pipe_d"
 	density = TRUE
 	anchored = TRUE
+	unacidable = TRUE
 	var/unwrenched = 0
 	var/wait = 0
 	var/p_layer = PIPING_LAYER_REGULAR

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -5,6 +5,7 @@
 	icon_state = "borgcharger0"
 	density = TRUE
 	anchored = TRUE
+	unacidable = TRUE
 	circuit = /obj/item/weapon/circuitboard/recharge_station
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 50

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -17,6 +17,7 @@
 	name = "status display"
 	anchored = TRUE
 	density = FALSE
+	unacidable = TRUE
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 10
 	circuit =  /obj/item/weapon/circuitboard/status_display

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -17,6 +17,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 
 /obj/machinery/telecomms
 	icon = 'icons/obj/stationobjs_vr.dmi' //VOREStation Add
+	unacidable = TRUE
 	var/list/links = list() // list of machines this machine is linked to
 	var/traffic = 0 // value increases as traffic increases
 	var/netspeed = 5 // how much traffic to lose per tick (50 gigabytes/second * netspeed)

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -13,6 +13,7 @@
 	icon_state = "control_standby"
 	anchored = TRUE
 	density = FALSE
+	unacidable = TRUE
 	var/enabled = FALSE
 	var/lethal = FALSE
 	var/lethal_is_configurable = TRUE

--- a/code/game/mecha/mech_prosthetics.dm
+++ b/code/game/mecha/mech_prosthetics.dm
@@ -5,6 +5,7 @@
 	desc = "A machine used for construction of prosthetics."
 	density = TRUE
 	anchored = TRUE
+	unacidable = TRUE
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 20
 	active_power_usage = 5000

--- a/code/game/objects/effects/alien/aliens.dm
+++ b/code/game/objects/effects/alien/aliens.dm
@@ -164,6 +164,7 @@
 	icon_state = "weeds"
 	anchored = TRUE
 	density = FALSE
+	unacidable = TRUE
 	plane = TURF_PLANE
 	layer = ABOVE_TURF_LAYER
 
@@ -402,10 +403,13 @@
 		for(var/mob/O in hearers(src, null))
 			O.show_message("<span class='alium'>[src.target] collapses under its own weight into a puddle of goop and undigested debris!</span>", 1)
 
-		if(istype(target, /turf/simulated/wall)) // I hate turf code.
+		if(iswall(target)) //Gurgs : Spruced up corrosive acid
 			var/turf/simulated/wall/W = target
 			W.dismantle_wall(1)
-		else
+		if(isfloor(target))
+			var/turf/simulated/floor/T = target
+			T.ex_act(1)
+		else if(isobj(target))
 			qdel(target)
 		qdel(src)
 		return

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -13,6 +13,7 @@
 	throwforce = 6
 	preserve_item = 1
 	w_class = ITEMSIZE_LARGE
+	unacidable = TRUE
 	origin_tech = list(TECH_BIO = 4, TECH_POWER = 2)
 	action_button_name = "Remove/Replace Paddles"
 

--- a/code/game/objects/structures/alien/alien.dm
+++ b/code/game/objects/structures/alien/alien.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/mob/alien.dmi'
 	layer = ABOVE_JUNK_LAYER
 	var/health = 50
+	unacidable = TRUE
 
 /obj/structure/alien/proc/healthcheck()
 	if(health <=0)

--- a/code/game/objects/structures/cliff.dm
+++ b/code/game/objects/structures/cliff.dm
@@ -33,6 +33,7 @@ two tiles on initialization, and which way a cliff is facing may change during m
 	opacity = FALSE
 	climbable = TRUE
 	climb_delay = 10 SECONDS
+	unacidable = TRUE
 	block_turf_edges = TRUE // Don't want turf edges popping up from the cliff edge.
 	plane = TURF_PLANE
 

--- a/code/game/objects/structures/ghost_pods/ghost_pods.dm
+++ b/code/game/objects/structures/ghost_pods/ghost_pods.dm
@@ -8,6 +8,7 @@
 	var/used = FALSE
 	var/busy = FALSE // Don't spam ghosts by spamclicking.
 	var/needscharger //For drone pods that want their pod to turn into a charger.
+	unacidable = TRUE
 
 // Call this to get a ghost volunteer.
 /obj/structure/ghost_pod/proc/trigger(var/alert, var/adminalert)

--- a/code/game/objects/structures/loot_piles.dm
+++ b/code/game/objects/structures/loot_piles.dm
@@ -21,6 +21,7 @@ Loot piles can be depleted, if loot_depleted is turned on.  Note that players wh
 	icon_state = "randompile"
 	density = FALSE
 	anchored = TRUE
+	unacidable = TRUE
 
 	var/list/icon_states_to_use = list() // List of icon states the pile can choose from on initialization. If empty or null, it will stay the initial icon_state.
 

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -20,6 +20,7 @@
 	var/obj/structure/m_tray/connected = null
 	var/list/occupants = list()
 	anchored = TRUE
+	unacidable = TRUE
 
 /obj/structure/morgue/Destroy()
 	if(connected)

--- a/code/game/objects/structures/stasis_cage.dm
+++ b/code/game/objects/structures/stasis_cage.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/storage_vr.dmi' //VOREStation Edit
 	icon_state = "critteropen"
 	density = TRUE
+	unacidable = TRUE
 
 	var/mob/living/simple_mob/contained
 

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -6,6 +6,7 @@
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "nest"
 	var/health = 100
+	unacidable = TRUE
 
 /obj/structure/bed/nest/update_icon()
 	return

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -1,6 +1,7 @@
 /obj/structure/shuttle
 	name = "shuttle"
 	icon = 'icons/turf/shuttle_parts.dmi'
+	unacidable = TRUE
 
 /obj/structure/shuttle/window
 	name = "shuttle window"

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -202,7 +202,7 @@ var/list/flooring_types
 	desc = "Gritty and unpleasant."
 	icon = 'icons/turf/flooring/asteroid.dmi'
 	icon_base = "asteroid"
-	flags = TURF_REMOVE_SHOVEL
+	flags = TURF_REMOVE_SHOVEL | TURF_ACID_IMMUNE
 	build_type = null
 	footstep_sounds = list("human" = list(
 		'sound/effects/footstep/asteroid1.ogg',
@@ -531,7 +531,7 @@ var/list/flooring_types
 	icon = 'icons/turf/outdoors.dmi'
 	icon_base = "lava"
 	is_plating = TRUE
-	flags = 0
+	flags = TURF_ACID_IMMUNE
 	footstep_sounds = list("human" = list(
 		'sound/effects/footstep/lava1.ogg',
 		'sound/effects/footstep/lava2.ogg',

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -76,6 +76,7 @@
 	icon = 'icons/turf/shuttle_white.dmi'
 	thermal_conductivity = 0.05
 	heat_capacity = 0
+	flags = TURF_ACID_IMMUNE
 
 	var/obj/landed_holder/landed_holder
 	var/interior_corner = 0

--- a/code/game/turfs/simulated/lava.dm
+++ b/code/game/turfs/simulated/lava.dm
@@ -15,6 +15,7 @@
 	can_build_into_floor = TRUE
 	can_dirty = FALSE
 	initial_flooring = /decl/flooring/lava // Defining this in case someone DOES step on lava and survive. Somehow.
+	flags = TURF_ACID_IMMUNE
 
 /turf/simulated/floor/lava/outdoors
 	outdoors = TRUE

--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -9,6 +9,7 @@
 	edge_blending_priority = -1
 	movement_cost = 4
 	outdoors = TRUE
+	flags = TURF_ACID_IMMUNE
 
 	layer = WATER_FLOOR_LAYER
 

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -4,7 +4,7 @@
 	icon_state = "default"
 	dynamic_lighting = 0
 	plane = SPACE_PLANE
-
+	flags = TURF_ACID_IMMUNE
 	temperature = T20C
 	thermal_conductivity = OPEN_HEAT_TRANSFER_COEFFICIENT
 	can_build_into_floor = TRUE

--- a/code/game/turfs/unsimulated.dm
+++ b/code/game/turfs/unsimulated.dm
@@ -3,6 +3,7 @@
 	oxygen = MOLES_O2STANDARD
 	nitrogen = MOLES_N2STANDARD
 	var/skip_init = TRUE // Don't call down the chain, apparently for performance when loading maps at runtime.
+	flags = TURF_ACID_IMMUNE
 
 /turf/unsimulated/Initialize(mapload)
 	if(skip_init)

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -5,6 +5,7 @@
 	icon_state = "off"
 	density = TRUE
 	anchored = TRUE
+	unacidable = TRUE
 	var/active = 0
 
 

--- a/code/modules/economy/vending.dm
+++ b/code/modules/economy/vending.dm
@@ -13,6 +13,7 @@
 	icon_state = "generic"
 	anchored = TRUE
 	density = TRUE
+	unacidable = TRUE
 	clicksound = "button"
 
 	// Power

--- a/code/modules/food/kitchen/gibber.dm
+++ b/code/modules/food/kitchen/gibber.dm
@@ -6,6 +6,7 @@
 	icon_state = "grinder"
 	density = TRUE
 	anchored = TRUE
+	unacidable = TRUE
 	req_access = list(access_kitchen,access_morgue)
 
 	var/operating = 0 //Is it on?

--- a/code/modules/food/kitchen/microwave.dm
+++ b/code/modules/food/kitchen/microwave.dm
@@ -6,6 +6,7 @@
 	layer = 2.9
 	density = TRUE
 	anchored = TRUE
+	unacidable = TRUE
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 5
 	active_power_usage = 2000

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -5,6 +5,7 @@
 
 /turf/simulated/floor/holofloor
 	thermal_conductivity = 0
+	flags = TURF_ACID_IMMUNE
 
 /turf/simulated/floor/holofloor/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	return
@@ -129,12 +130,14 @@
 	icon = 'icons/obj/furniture.dmi'
 	icon_state = "stool_padded_preview"
 	anchored = TRUE
+	unacidable = TRUE
 	pressure_resistance = 15
 
 /obj/item/clothing/gloves/boxing/hologlove
 	name = "boxing gloves"
 	desc = "Because you really needed another excuse to punch your crewmates."
 	icon_state = "boxing"
+	unacidable = TRUE
 	item_icons = list(
 			slot_l_hand_str = 'icons/mob/items/lefthand_gloves.dmi',
 			slot_r_hand_str = 'icons/mob/items/righthand_gloves.dmi',
@@ -291,6 +294,7 @@
 	throwforce = 0
 	w_class = ITEMSIZE_SMALL
 	flags = NOBLOODY
+	unacidable = TRUE
 	var/active = 0
 
 /obj/item/weapon/holo/esword/green/New()
@@ -359,6 +363,7 @@
 	name = "basketball"
 	desc = "Here's your chance, do your dance at the Space Jam."
 	w_class = ITEMSIZE_LARGE //Stops people from hiding it in their bags/pockets
+	unacidable = TRUE
 	drop_sound = 'sound/items/drop/basketball.ogg'
 	pickup_sound = 'sound/items/pickup/basketball.ogg'
 
@@ -369,6 +374,7 @@
 	icon_state = "hoop"
 	anchored = TRUE
 	density = TRUE
+	unacidable = TRUE
 	throwpass = 1
 
 /obj/structure/holohoop/attackby(obj/item/weapon/W as obj, mob/user as mob)
@@ -411,6 +417,7 @@
 	var/area/currentarea = null
 	var/eventstarted = 0
 
+	unacidable = TRUE
 	anchored = TRUE
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 2

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -5,6 +5,7 @@
 	icon_state = "hydrotray3"
 	density = TRUE
 	anchored = TRUE
+	unacidable = TRUE
 	flags = OPENCONTAINER
 	volume = 100
 

--- a/code/modules/looking_glass/lg_turfs.dm
+++ b/code/modules/looking_glass/lg_turfs.dm
@@ -14,6 +14,7 @@
 	initial_flooring = /decl/flooring/looking_glass
 	appearance_flags = TILE_BOUND
 	dynamic_lighting = FALSE
+	flags = TURF_ACID_IMMUNE
 
 	var/center = FALSE
 	var/optional = FALSE

--- a/code/modules/materials/materials/glass.dm
+++ b/code/modules/materials/materials/glass.dm
@@ -141,3 +141,4 @@
 	stack_origin_tech = list(TECH_MATERIAL = 2)
 	composite_material = list(MAT_STEEL = SHEET_MATERIAL_AMOUNT / 2, "borosilicate glass" = SHEET_MATERIAL_AMOUNT)
 	rod_product = null
+	flags = MATERIAL_UNMELTABLE

--- a/code/modules/materials/materials/metals/hull.dm
+++ b/code/modules/materials/materials/metals/hull.dm
@@ -6,6 +6,7 @@
 	icon_base = "hull"
 	icon_reinf = "reinf_mesh"
 	icon_colour = "#666677"
+	flags = MATERIAL_UNMELTABLE
 
 /datum/material/steel/hull/place_sheet(var/turf/target) //Deconstructed into normal steel sheets.
 	new /obj/item/stack/material/steel(target)
@@ -18,6 +19,7 @@
 	icon_reinf = "reinf_mesh"
 	icon_colour = "#777788"
 	explosion_resistance = 40
+	flags = MATERIAL_UNMELTABLE
 
 /datum/material/plasteel/hull/place_sheet(var/turf/target) //Deconstructed into normal plasteel sheets.
 	new /obj/item/stack/material/plasteel(target)
@@ -30,6 +32,7 @@
 	icon_colour = "#45829a"
 	explosion_resistance = 90
 	reflectivity = 0.9
+	flags = MATERIAL_UNMELTABLE
 
 /datum/material/durasteel/hull/place_sheet(var/turf/target) //Deconstructed into normal durasteel sheets.
 	new /obj/item/stack/material/durasteel(target)
@@ -39,6 +42,7 @@
 	stack_type = /obj/item/stack/material/titanium/hull
 	icon_base = "hull"
 	icon_reinf = "reinf_mesh"
+	flags = MATERIAL_UNMELTABLE
 
 /datum/material/titanium/hull/place_sheet(var/turf/target) //Deconstructed into normal titanium sheets.
 	new /obj/item/stack/material/titanium(target)
@@ -48,6 +52,7 @@
 	stack_type = /obj/item/stack/material/morphium/hull
 	icon_base = "hull"
 	icon_reinf = "reinf_mesh"
+	flags = MATERIAL_UNMELTABLE
 
 /datum/material/morphium/hull/place_sheet(var/turf/target)
 	new /obj/item/stack/material/morphium(target)

--- a/code/modules/materials/materials/supermatter.dm
+++ b/code/modules/materials/materials/supermatter.dm
@@ -16,6 +16,7 @@
 	sheet_plural_name = "crystals"
 	is_fusion_fuel = 1
 	stack_origin_tech = list(TECH_MATERIAL = 8, TECH_PHORON = 5, TECH_BLUESPACE = 4)
+	flags = MATERIAL_UNMELTABLE
 
 /datum/material/supermatter/generate_recipes()
 	recipes = list(

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_powers.dm
@@ -158,21 +158,20 @@
 	// OBJ CHECK
 	var/cannot_melt
 	if(isobj(O))
-		var/obj/I = O
+		var/obj/I = O //Gurgs : Melts pretty much any object that isn't considered unacidable = TRUE
 		if(I.unacidable)
 			cannot_melt = 1
 	else
 		if(istype(O, /turf/simulated/wall))
-			var/turf/simulated/wall/W = O
+			var/turf/simulated/wall/W = O //Gurgs : Walls are deconstructed into girders.
 			if(W.material.flags & MATERIAL_UNMELTABLE)
 				cannot_melt = 1
 		else if(istype(O, /turf/simulated/floor))
-/*			var/turf/simulated/floor/F = O							//Turfs are qdel'd to space (Even asteroid tiles), will need to be touched by someone smarter than myself. -Mech
+			var/turf/simulated/floor/F = O	//Gurgs : Floors are destroyed with ex_act(1), turning them into whatever tile it would be if empty. Z-Level Friendly, does not destroy pipes.
 			if(F.flooring && (F.flooring.flags & TURF_ACID_IMMUNE))
-*/
-			cannot_melt = 1
+				cannot_melt = 1
 		else
-			cannot_melt = 1
+			cannot_melt = 1 //Gurgs : Everything that isn't a object, simulated wall, or simulated floor is assumed to be acid immune. Includes weird things like unsimulated floors and space.
 
 	if(cannot_melt)
 		to_chat(src, "<span class='alium'>You cannot dissolve this object.</span>")

--- a/code/modules/multiz/stairs.dm
+++ b/code/modules/multiz/stairs.dm
@@ -8,6 +8,7 @@
 	opacity = 0
 	density = FALSE
 	anchored = TRUE
+	unacidable = TRUE
 	layer = STAIRS_LAYER
 
 /obj/structure/stairs/Initialize()

--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -21,6 +21,7 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 
 	icon = 'icons/obj/device_alt.dmi'
 	icon_state = "nif_0"
+	unacidable = TRUE
 
 	w_class = ITEMSIZE_TINY
 	var/known_implant = TRUE

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -82,6 +82,7 @@ GLOBAL_LIST_EMPTY(apcs)
 	icon_state = "apc0"
 	layer = ABOVE_WINDOW_LAYER
 	anchored = TRUE
+	unacidable = TRUE
 	use_power = USE_POWER_OFF
 	clicksound = "switch"
 	req_access = list(access_engine_equip)

--- a/code/modules/power/breaker_box.dm
+++ b/code/modules/power/breaker_box.dm
@@ -14,6 +14,7 @@
 	var/icon_state_off = "bbox_off"
 	density = TRUE
 	anchored = TRUE
+	unacidable = TRUE
 	circuit = /obj/item/weapon/circuitboard/breakerbox
 	var/on = 0
 	var/busy = 0

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -46,6 +46,7 @@ var/list/possible_cable_coil_colours = list(
 /obj/structure/cable
 	level = 1
 	anchored =TRUE
+	unacidable = TRUE
 	var/datum/powernet/powernet
 	name = "power cable"
 	desc = "A flexible superconducting cable for heavy-duty power transfer."

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -6,6 +6,7 @@ GLOBAL_LIST_EMPTY(all_turbines)
 	icon_state = "teg-unassembled"
 	density = TRUE
 	anchored = FALSE
+	unacidable = TRUE
 
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 100 //Watts, I hope.  Just enough to do the computer and display things.

--- a/code/modules/power/gravitygenerator_vr.dm
+++ b/code/modules/power/gravitygenerator_vr.dm
@@ -24,6 +24,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 	icon = 'icons/obj/machines/gravity_generator.dmi'
 	anchored = TRUE
 	density = TRUE
+	unacidable = TRUE
 	use_power = USE_POWER_OFF
 	var/sprite_number = 0
 

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -7,6 +7,7 @@
 	icon_state = "emitter"
 	anchored = FALSE
 	density = TRUE
+	unacidable = TRUE
 	req_access = list(access_engine_equip)
 	var/id = null
 

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -12,6 +12,7 @@ GLOBAL_LIST_EMPTY(smeses)
 	icon_state = "smes"
 	density = TRUE
 	anchored = TRUE
+	unacidable = TRUE
 	use_power = USE_POWER_OFF
 	circuit = /obj/item/weapon/circuitboard/smes
 	clicksound = "switch"

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -13,6 +13,7 @@ GLOBAL_LIST_EMPTY(solars_list)
 	icon_state = "sp_base"
 	anchored = TRUE
 	density = TRUE
+	unacidable = TRUE
 	use_power = USE_POWER_OFF
 	idle_power_usage = 0
 	active_power_usage = 0

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -55,6 +55,7 @@
 	layer = ABOVE_MOB_LAYER // So people can walk behind the top part
 	density = TRUE
 	anchored = FALSE
+	unacidable = TRUE
 	light_range = 4
 
 	var/gasefficency = 0.25

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -159,6 +159,7 @@
 	force = 5
 	slot_flags = SLOT_BELT
 	w_class = ITEMSIZE_NORMAL
+	unacidable = TRUE
 	projectile_type = /obj/item/projectile/beam
 	origin_tech = null
 	fire_delay = 10		//Old pistol

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -3,6 +3,7 @@
 	desc = "Used to seperate and package chemicals in to patches, pills, or bottles. Warranty void if used to create Space Drugs."
 	density = TRUE
 	anchored = TRUE
+	unacidable = TRUE
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "mixer0"
 	circuit = /obj/item/weapon/circuitboard/chem_master

--- a/code/modules/reagents/machinery/dispenser/dispenser2.dm
+++ b/code/modules/reagents/machinery/dispenser/dispenser2.dm
@@ -18,6 +18,7 @@
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 100
 	anchored = TRUE
+	unacidable = TRUE
 
 /obj/machinery/chemical_dispenser/Initialize()
 	. = ..()

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -743,6 +743,7 @@
 	desc = "An underfloor disposal pipe."
 	anchored = TRUE
 	density = FALSE
+	unacidable = TRUE
 
 	level = 1			// underfloor only
 	var/dpdir = 0		// bitmask of pipe directions

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -54,6 +54,7 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	desc = "Facilitates both PDA messages and request console functions."
 	density = TRUE
 	anchored = TRUE
+	unacidable = TRUE
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 10
 	active_power_usage = 100
@@ -239,6 +240,7 @@ var/obj/machinery/blackbox_recorder/blackbox
 	desc = "Records all radio communications, as well as various other information in case of the worst."
 	density = TRUE
 	anchored = TRUE
+	unacidable = TRUE
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 10
 	active_power_usage = 100

--- a/code/modules/shuttles/escape_pods.dm
+++ b/code/modules/shuttles/escape_pods.dm
@@ -44,6 +44,7 @@
 //This controller goes on the escape pod itself
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod
 	name = "escape pod controller"
+	unacidable = TRUE
 	program = /datum/embedded_program/docking/simple
 	var/datum/shuttle/autodock/ferry/escape_pod/pod
 	valid_actions = list("toggle_override", "force_door")

--- a/code/modules/turbolift/turbolift_door.dm
+++ b/code/modules/turbolift/turbolift_door.dm
@@ -2,6 +2,7 @@
 	name = "Elevator Door"
 	desc = "Ding."
 	req_access = list(access_maint_tunnels)
+	unacidable = TRUE
 	opacity = 0
 	autoclose = 0
 	glass = 1


### PR DESCRIPTION
Fixes floor acid interactions, and makes ALOT of important stuff immune to acid.

- Readds the ability for xenomorphs to melt through floors.
- Refactors some of the corrosive acid code so it properly removes floors, instead of the old version that is incompatible with z-levels.
- Adds a obj clause to corrosive acid so it knows what to do with it.
- Makes a metric ton of stuff immune to corrosive acid, because there is roughly 8 years of content that does not have this important var.