### PR TITLE
Bypass dept hour limit as a staff member.

### DIFF
--- a/code/game/jobs/job/job_vr.dm
+++ b/code/game/jobs/job/job_vr.dm
@@ -25,7 +25,7 @@
 	return (available_in_playhours(C) == 0)
 
 /datum/job/proc/available_in_playhours(client/C)
-	if(C && (C.check_rights(R_ADMIN, 0) || C.check_rights(R_MOD, 0)))	return 1 // Gurgs ADD: Bypass dept hour limit as staff.
+	if(check_rights(R_ADMIN | R_MOD, 0, C)	return 1 // Gurgs ADD: Bypass dept hour limit as staff.
 	if(C && config.use_playtime_restriction_for_jobs && dept_time_required)
 		if(isnum(C.play_hours[pto_type])) // Has played that department before
 			return max(0, dept_time_required - C.play_hours[pto_type])

--- a/code/game/jobs/job/job_vr.dm
+++ b/code/game/jobs/job/job_vr.dm
@@ -25,7 +25,7 @@
 	return (available_in_playhours(C) == 0)
 
 /datum/job/proc/available_in_playhours(client/C)
-	if(check_rights(R_ADMIN | R_MOD, 0, C)	return 1 // Gurgs ADD: Bypass dept hour limit as staff.
+	if(check_rights(R_ADMIN | R_MOD, 0, C))	return 1 // Gurgs ADD: Bypass dept hour limit as staff.
 	if(C && config.use_playtime_restriction_for_jobs && dept_time_required)
 		if(isnum(C.play_hours[pto_type])) // Has played that department before
 			return max(0, dept_time_required - C.play_hours[pto_type])

--- a/code/game/jobs/job/job_vr.dm
+++ b/code/game/jobs/job/job_vr.dm
@@ -25,7 +25,7 @@
 	return (available_in_playhours(C) == 0)
 
 /datum/job/proc/available_in_playhours(client/C)
-	if(C && (is_job_whitelisted(C, src) || check_rights(R_MOD, 0)))	return 1 // Gurgs ADD: Bypass dept hour limit via whitelist check. Also note, admin rights are checked in job_whitelist proc.
+	if(C && (C.check_rights(R_ADMIN, 0) || C.check_rights(R_MOD, 0)))	return 1 // Gurgs ADD: Bypass dept hour limit as staff.
 	if(C && config.use_playtime_restriction_for_jobs && dept_time_required)
 		if(isnum(C.play_hours[pto_type])) // Has played that department before
 			return max(0, dept_time_required - C.play_hours[pto_type])

--- a/code/game/jobs/job/job_vr.dm
+++ b/code/game/jobs/job/job_vr.dm
@@ -25,6 +25,7 @@
 	return (available_in_playhours(C) == 0)
 
 /datum/job/proc/available_in_playhours(client/C)
+	if(C && (is_job_whitelisted(C, src) || check_rights(R_MOD, 0)))	return 1 // Gurgs ADD: Bypass dept hour limit via whitelist check. Also note, admin rights are checked in job_whitelist proc.
 	if(C && config.use_playtime_restriction_for_jobs && dept_time_required)
 		if(isnum(C.play_hours[pto_type])) // Has played that department before
 			return max(0, dept_time_required - C.play_hours[pto_type])


### PR DESCRIPTION
I would have done this for whitelisted players but if job whitelist is disabled in config, the job whitelist functions won't work and I cannot really work with it unfortunately.