### PR TITLE
Removes some obnoxious xenochimera stuff, added more trait availability

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -200,7 +200,7 @@
 			if(!feral) return //just to avoid fuckery in the event that they un-feral in the time it takes for the spawn to proc
 			var/halpick = rand(1,100)
 			switch(halpick)
-				if(0 to 15) //15% chance
+				/*if(0 to 15) //15% chance |Gurg Edit, some hallucination types removed to make xenochimera less obnoxious to play|
 					//Screwy HUD
 					//to_chat(src, "Screwy HUD")
 					hal_screwyhud = pick(1,2,3,3,4,4)
@@ -253,7 +253,7 @@
 							spawn(rand(100,250))
 								if(client)
 									client.screen -= halitem
-								halitem = null
+								halitem = null */
 				if(26 to 35) //10% chance
 					//Flashes of danger
 					//to_chat(src, "Danger Flash")
@@ -281,7 +281,7 @@
 								if(client) client.images -= halimage
 								halimage = null
 
-				if(36 to 55) //20% chance
+				/*if(36 to 55) //20% chance |Gurg Edit, some hallucination types removed to make xenochimera less obnoxious to play|
 					//Strange audio
 					//to_chat(src, "Strange Audio")
 					switch(rand(1,12))
@@ -337,7 +337,7 @@
 							if(client) client.images += halbody
 							spawn(rand(50,80)) //Only seen for a brief moment.
 								if(client) client.images -= halbody
-								halbody = null
+								halbody = null */
 				if(61 to 85) //25% chance
 					//food
 					if(!halbody)
@@ -372,12 +372,12 @@
 							spawn(rand(50,80)) //Only seen for a brief moment.
 								if(client) client.images -= halbody
 								halbody = null
-				if(86 to 100) //15% chance
+				/*if(86 to 100) //15% chance |Gurg Edit, some hallucination types removed to make xenochimera less obnoxious to play|
 					//hear voices. Could make the voice pick from nearby creatures, but nearby creatures make feral hallucinations rare so don't bother.
 					var/list/hiddenspeakers = list("Someone distant", "A voice nearby","A familiar voice", "An echoing voice", "A cautious voice", "A scared voice", "Someone around the corner", "Someone", "Something", "Something scary", "An urgent voice", "An angry voice")
 					var/list/speakerverbs = list("calls out", "yells", "screams", "exclaims", "shrieks", "shouts", "hisses", "snarls")
 					var/list/spookyphrases = list("It's over here!","Stop it!", "Hunt it down!", "Get it!", "Quick, over here!", "Anyone there?", "Who's there?", "Catch that thing!", "Stop it! Kill it!", "Anyone there?", "Where is it?", "Find it!", "There it is!")
-					to_chat(src, "<span class='game say'><span class='name'>[pick(hiddenspeakers)]</span> [pick(speakerverbs)], \"[pick(spookyphrases)]\"</span>")
+					to_chat(src, "<span class='game say'><span class='name'>[pick(hiddenspeakers)]</span> [pick(speakerverbs)], \"[pick(spookyphrases)]\"</span>") */
 
 
 	handling_hal = 0

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -5,24 +5,28 @@
 	name = "Slowdown"
 	desc = "Allows you to move slower on average than baseline."
 	cost = -2
+	custom_only = FALSE //Gurg edit, allows all species to walk slower
 	var_changes = list("slowdown" = 0.5)
 
 /datum/trait/negative/speed_slow_plus
 	name = "Slowdown, Major"
 	desc = "Allows you to move MUCH slower on average than baseline."
 	cost = -3
+	custom_only = FALSE //Gurg edit, allows all species to walk slower
 	var_changes = list("slowdown" = 1.0)
 
 /datum/trait/negative/weakling
 	name = "Weakling"
 	desc = "Causes heavy equipment to slow you down more when carried."
 	cost = -1
+	custom_only = FALSE //Gurg edit, allows all species to be weak
 	var_changes = list("item_slowdown_mod" = 1.5)
 
 /datum/trait/negative/weakling_plus
 	name = "Weakling, Major"
 	desc = "Allows you to carry heavy equipment with much more slowdown."
 	cost = -2
+	custom_only = FALSE //Gurg edit, allows all species to be weak
 	var_changes = list("item_slowdown_mod" = 2.0)
 
 /datum/trait/negative/endurance_low
@@ -167,4 +171,3 @@
 	var_changes = list("gun_accuracy_mod" = -35)
 	custom_only = FALSE
 	varchange_type = TRAIT_VARCHANGE_MORE_BETTER
-

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -5,6 +5,7 @@
 	name = "Metabolism, Fast"
 	desc = "You process ingested and injected reagents faster, but get hungry faster (Teshari speed)."
 	cost = 0
+	custom_only = FALSE //Gurg edit, allows all species to change metabolism
 	var_changes = list("metabolic_rate" = 1.2, "hunger_factor" = 0.2, "metabolism" = 0.06) // +20% rate and 4x hunger (Teshari level)
 	excludes = list(/datum/trait/neutral/metabolism_down, /datum/trait/neutral/metabolism_apex)
 
@@ -12,6 +13,7 @@
 	name = "Metabolism, Slow"
 	desc = "You process ingested and injected reagents slower, but get hungry slower."
 	cost = 0
+	custom_only = FALSE //Gurg edit, allows all species to change metabolism
 	var_changes = list("metabolic_rate" = 0.8, "hunger_factor" = 0.04, "metabolism" = 0.0012) // -20% of default.
 	excludes = list(/datum/trait/neutral/metabolism_up, /datum/trait/neutral/metabolism_apex)
 
@@ -19,6 +21,7 @@
 	name = "Metabolism, Apex"
 	desc = "Finally a proper excuse for your predatory actions. Essentially doubles the fast trait rates. Good for characters with big appetites."
 	cost = 0
+	custom_only = FALSE //Gurg edit, allows all species to change metabolism
 	var_changes = list("metabolic_rate" = 1.4, "hunger_factor" = 0.4, "metabolism" = 0.012) // +40% rate and 8x hunger (Double Teshari)
 	excludes = list(/datum/trait/neutral/metabolism_up, /datum/trait/neutral/metabolism_down)
 


### PR DESCRIPTION
This little pull has two separate parts : removing obnoxious xenochimera feral mechanics, and making some traits available for all species.

- ### Xenochimera changes
1. Commented out "Screwy HUD" hallucination chance from feral hallucination list
2. Commented out sound hallucination chance from feral hallucination list. Includes explosions, gunshots, hidden-source sound effects, and other obnoxious sounds.
3. Commented out hallucination speech coming from nowhere in particular, or mimicking people you can see. You're feral, not insane.
4. Commented out some mob and item hallucinations, like weapons or items in-hand that don't exist, or hallucinations chasing you. Once again, feral, not insane. Left hallucinations of food and a few turf danger hallucinations.

- ### Trait Availability changes
1. Slowdown, and Major Slowdown are available for all species.
2. Weakling, and Weakling Major are available for all species.
3. Fast, Slow, and Apex Metabolism are available for all species.