### PR TITLE
Expands Trash Eater perk, expands indigestable and ingestion blacklists

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -46,7 +46,16 @@ var/global/list/item_vore_blacklist = list(
 		/obj/item/areaeditor/blueprints,
 		/obj/item/clothing/head/helmet/space,
 		/obj/item/weapon/disk/nuclear,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/roiz)
+		/obj/item/clothing/suit/storage/hooded/wintercoat/roiz,
+		/obj/item/device/perfect_tele,
+		/obj/item/weapon/rig,
+		/obj/item/clothing/suit/radiation,
+		/obj/item/clothing/head/radiation,
+		/obj/item/clothing/suit/bio_suit,
+		/obj/item/clothing/head/bio_hood,
+		/obj/item/clothing/suit/space,
+		/obj/item/clothing/suit/armor,
+		/obj/item/clothing/head/helmet)
 
 //Classic Vore sounds
 var/global/list/classic_vore_sounds = list(
@@ -185,13 +194,8 @@ var/global/list/tf_vore_egg_types = list(
 	"Spotted pink"	= /obj/item/weapon/storage/vore_egg/pinkspots)
 
 var/global/list/edible_trash = list(/obj/item/broken_device,
-				/obj/item/clothing/accessory/collar,
+				/obj/item/clothing, //indigestable and inedible list being expanded to prevent nom shenanigans with this
 				/obj/item/device/communicator,
-				/obj/item/clothing/mask,
-				/obj/item/clothing/glasses,
-				/obj/item/clothing/gloves,
-				/obj/item/clothing/head,
-				/obj/item/clothing/shoes,
 				/obj/item/device/aicard,
 				/obj/item/device/flashlight,
 				/obj/item/device/mmi/digital/posibrain,
@@ -207,9 +211,7 @@ var/global/list/edible_trash = list(/obj/item/broken_device,
 				/obj/item/weapon/bananapeel,
 				/obj/item/weapon/bone,
 				/obj/item/weapon/broken_bottle,
-				/obj/item/weapon/card/emag_broken,
 				/obj/item/trash/cigbutt,
-				/obj/item/weapon/circuitboard/broken,
 				/obj/item/weapon/clipboard,
 				/obj/item/weapon/corncob,
 				/obj/item/weapon/dice,
@@ -226,18 +228,32 @@ var/global/list/edible_trash = list(/obj/item/broken_device,
 				/obj/item/weapon/reagent_containers/glass/rag,
 				/obj/item/weapon/soap,
 				/obj/item/weapon/spacecash,
-				/obj/item/weapon/storage/box/khcrystal,
-				/obj/item/weapon/storage/box/matches,
-				/obj/item/weapon/storage/box/wings,
+				/obj/item/weapon/storage/box, //Can eat boxes now, expanded indigestable list to prevent shenanigan
 				/obj/item/weapon/storage/fancy/candle_box,
 				/obj/item/weapon/storage/fancy/cigarettes,
 				/obj/item/weapon/storage/fancy/crayons,
 				/obj/item/weapon/storage/fancy/egg_box,
 				/obj/item/weapon/storage/wallet,
 				/obj/item/weapon/storage/vore_egg,
-				/obj/item/weapon/bikehorn/tinytether,
+				/obj/item/weapon/bikehorn, //This includes rubber duckies
 				/obj/item/capture_crystal,
-				/obj/item/roulette_ball
+				/obj/item/roulette_ball,
+				/obj/item/weapon/hand, //Playing cards from a deck
+				/obj/item/weapon/tool, //My hydrospanner!
+				/obj/item/stack/cable_coil, //Mmm, metal spaghetti
+				/obj/item/stack/material/wood, //Wood is edible, right?
+				/obj/item/seeds, //Birds like seeds, right?
+				/obj/item/weapon/towel,
+				/obj/item/weapon/tape_roll,
+				/obj/item/weapon/book,
+				/obj/item/weapon/folder,
+				/obj/item/device/tape,
+				/obj/item/weapon/beach_ball, //You absolute buffoon
+				/obj/item/weapon/stock_parts, //For when you accidentally make 20+ T1 parts
+				/obj/item/weapon/cell,
+				/obj/item/weapon/coin,
+				/obj/item/weapon/glass_extra, //Straws for bar glasses, bar glass sticks
+				/obj/item/device/megaphone //Don't know why you would want to, but you can now
 				)
 
 var/global/list/contamination_flavors = list(

--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -251,7 +251,8 @@ var/global/list/edible_trash = list(/obj/item/broken_device,
 				/obj/item/weapon/cell,
 				/obj/item/weapon/coin,
 				/obj/item/weapon/glass_extra, //Straws for bar glasses, bar glass sticks
-				/obj/item/device/megaphone //Don't know why you would want to, but you can now
+				/obj/item/device/megaphone, //Don't know why you would want to, but you can now
+				/obj/item/ammo_casing //Eat the brass you little rhoomba
 				)
 
 var/global/list/contamination_flavors = list(

--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -44,18 +44,16 @@ var/global/list/item_vore_blacklist = list(
 		/obj/item/weapon/pinpointer,
 		/obj/item/clothing/shoes/magboots,
 		/obj/item/areaeditor/blueprints,
-		/obj/item/clothing/head/helmet/space,
+		/obj/item/clothing/head/helmet,
 		/obj/item/weapon/disk/nuclear,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/roiz,
 		/obj/item/device/perfect_tele,
-		/obj/item/weapon/rig,
 		/obj/item/clothing/suit/radiation,
 		/obj/item/clothing/head/radiation,
 		/obj/item/clothing/suit/bio_suit,
 		/obj/item/clothing/head/bio_hood,
 		/obj/item/clothing/suit/space,
-		/obj/item/clothing/suit/armor,
-		/obj/item/clothing/head/helmet)
+		/obj/item/clothing/suit/armor,)
 
 //Classic Vore sounds
 var/global/list/classic_vore_sounds = list(

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -90,6 +90,62 @@
 	return FALSE //Sorta important to not digest your own beacons.
 /obj/item/organ/internal/brain/slime/digest_act(var/atom/movable/item_storage = null)
 	return FALSE //so prometheans can be recovered
+/obj/item/weapon/circuitboard/digest_act(var/atom/movable/item_storage = null)
+	return FALSE
+/obj/item/weapon/tank/digest_act(var/atom/movable/item_storage = null)
+	return FALSE //So you don't accidentally digest a oxygen tank
+/obj/item/weapon/reagent_containers/syringe/digest_act(var/atom/movable/item_storage = null)
+	return FALSE
+/obj/item/weapon/grenade/digest_act(var/atom/movable/item_storage = null)
+	return FALSE //Are you trying to explode?
+/obj/item/weapon/storage/pill_bottle/digest_act(var/atom/movable/item_storage = null)
+	return FALSE
+/obj/item/weapon/implant/digest_act(var/atom/movable/item_storage = null)
+	return FALSE
+/obj/item/weapon/reagent_containers/hypospray/digest_act(var/atom/movable/item_storage = null)
+	return FALSE
+/obj/item/clothing/suit/radiation/digest_act(var/atom/movable/item_storage = null)
+	return FALSE
+/obj/item/clothing/head/radiation/digest_act(var/atom/movable/item_storage = null)
+	return FALSE
+/obj/item/clothing/suit/bio_suit/digest_act(var/atom/movable/item_storage = null)
+	return FALSE
+/obj/item/clothing/head/bio_hood/digest_act(var/atom/movable/item_storage = null)
+	return FALSE
+/obj/item/clothing/suit/space/digest_act(var/atom/movable/item_storage = null)
+	return FALSE //You really shouldn't be digesting this
+/obj/item/clothing/suit/bomb_suit/digest_act(var/atom/movable/item_storage = null)
+	return FALSE
+/obj/item/clothing/head/bomb_hood/digest_act(var/atom/movable/item_storage = null)
+	return FALSE
+/obj/item/weapon/rig/digest_act(var/atom/movable/item_storage = null)
+	return FALSE //Seriously, don't digest this
+/obj/item/clothing/suit/armor/digest_act(var/atom/movable/item_storage = null)
+	return FALSE
+/obj/item/clothing/head/helmet/digest_act(var/atom/movable/item_storage = null)
+	return FALSE
+/obj/item/weapon/shield/digest_act(var/atom/movable/item_storage = null)
+	return FALSE //Alright big-mouth, spit it out
+/obj/item/device/nif/digest_act(var/atom/movable/item_storage = null)
+	return FALSE //I don't know why you would want to, just no
+/obj/item/ammo_magazine/digest_act(var/atom/movable/item_storage = null)
+	return FALSE //You really shouldn't digest ammo
+/obj/item/weapon/surgical/digest_act(var/atom/movable/item_storage = null)
+	return FALSE //Radar, where's my scalpel!?
+/obj/item/stack/medical/digest_act(var/atom/movable/item_storage = null)
+	return FALSE //What do you mean I can't digest gauze?
+/obj/item/device/defib_kit/digest_act(var/atom/movable/item_storage = null)
+	return FALSE //Why would you want to digest this?
+/obj/item/weapon/storage/box/freezer/digest_act(var/atom/movable/item_storage = null)
+	return FALSE //You don't get many of these, best to not digest it
+/obj/item/device/perfect_tele/digest_act(var/atom/movable/item_storage = null)
+	return FALSE //Like the handtele, but better. Don't digest this
+/obj/item/clothing/gloves/arm_guard/digest_act(var/atom/movable/item_storage = null)
+	return FALSE
+/obj/item/clothing/shoes/leg_guard/digest_act(var/atom/movable/item_storage = null)
+	return FALSE
+/obj/item/ammo_casing/digest_act(var/atom/movable/item_storage = null)
+	return FALSE //Remember not wanting to digest ammo? Same concept, just with shotgun shells
 
 /////////////
 // Some special treatment

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -144,8 +144,6 @@
 	return FALSE
 /obj/item/clothing/shoes/leg_guard/digest_act(var/atom/movable/item_storage = null)
 	return FALSE
-/obj/item/ammo_casing/digest_act(var/atom/movable/item_storage = null)
-	return FALSE //Remember not wanting to digest ammo? Same concept, just with shotgun shells
 
 /////////////
 // Some special treatment


### PR DESCRIPTION
Expands the edible list for the Trash Eater Perk to include ALOT of things. Expands inedible and indigestable lists to compensate for this fact.

- Things made edible for Trash Eater trait

All clothing, within reason
All kinds of basic boxes
Playing cards
Tools
Cable coils
Wood sheets
Hydroponic seeds
Towels
Tape rolls
Books
Folders
Magnetic tape for recorders
Beach balls
Tiered machine components, examples being capacitors and such
Battery cells
Coins
Those little bar glass sticks and straws
Megaphones
Ammo casings

- Things made inedible, or indigestable to offset the Trash Eater expansion
**Inedible : You can't normally eat it with things like the Trash Eater trait. Can still get in a belly through nom shenanigans.
Indigestable : Even if you somehow get it into a belly, it's never going to digest. Items with only indigestable can usually only be eaten through nom shenanigans.**

Spacesuits of all kinds and manner : Inedible and Indigestable
Radiation and Biohazard suits : Inedible and Indigestable
Perfect Hand Teleporter : Inedible and Indigestable
RIG suits : Indigestable
Armor, including helmets of both space and non-space type : Inedible and Indigestable
Circuitboards : Indigestable
Tanks, like oxygen tanks and such : Indigestable
Syringes : Indigestable
Grenades : Indigestable
Pill Bottles : Indigestable
Implants of all kinds, only includes ones outside the body : Indigestable
Hyposprays, and autoinjectors by extension : Indigestable
Shields : Indigestable
NIF : Indigestable
Ammo clips & magazines : Indigestable
Surgical equipment, example being a scalpel : Indigestable
Defib kits of all type : Indigestable
Medical Freezer box for organs : Indigestable