### PR TITLE
Fixes xenobotany locker so xenobotanists can open them

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -27,7 +27,7 @@
 
 /obj/structure/closet/secure_closet/hydroponics/sci
 	name = "xenoflorist's locker"
-	req_access = list(access_xenobiology)
+	req_access = list(access_xenobotany) //gurgs : fixed xenobotanists not being able to access their lockers, due to job separation
 	closet_appearance = /decl/closet_appearance/secure_closet/hydroponics/xenoflora
 
 /obj/structure/closet/secure_closet/hydroponics/sci/Initialize()


### PR DESCRIPTION
- Fixes xenobotany lockers, as they had xenobiologist access, and no xenobotany access. Xenobotany and Xenobiology used to be the same job, but now it obviously isn't. This causes access problems, this is one of those problems.