### PR TITLE
Smoking pipes now can fit in boxes and pockets

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -403,6 +403,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	description_fluff = "ClassiCo Accessories and Haberdashers, originating out of Mars, claim to produce products 'for the modern gentlefolk'. Most of their items are high-end and expensive, but they pledge to back their prices up with quality, and usually do."
 	icon_state = "pipe"
 	item_state = "pipe"
+	w_class = ITEMSIZE_SMALL
 	smoketime = 0
 	chem_volume = 50
 	matchmes = "<span class='notice'>USER lights their NAME with their FLAME.</span>"


### PR DESCRIPTION
- Smoking Pipes can now fit in pockets, boxes, and other small item storage things. It's just a smoking pipe, you should be allowed to put it in small things.