### PR TITLE
Changes Bluespace Bracelet cost in loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
@@ -72,7 +72,7 @@
 /datum/gear/utility/bs_bracelet
 	display_name = "bluespace bracelet"
 	path = /obj/item/clothing/gloves/bluespace
-	cost = 5
+	cost = 1 //Gurg edit, changed from 5 to 1 . Price does not line up with uses
 
 /datum/gear/utility/walkpod
 	display_name = "podzu music player"


### PR DESCRIPTION
Changes the price of the Bluespace Size Standardization Bracelet from 5 to 1. It's uses does not line up with the outright expensive cost of the bracelet, so it's getting a reduction to it's price.