### PR TITLE
Adds slime extract cores to trash eater ability

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -256,7 +256,8 @@ var/global/list/edible_trash = list(/obj/item/broken_device,
 				/obj/item/weapon/coin,
 				/obj/item/weapon/glass_extra, //Straws for bar glasses, bar glass sticks
 				/obj/item/device/megaphone, //Don't know why you would want to, but you can now
-				/obj/item/ammo_casing //Eat the brass you little rhoomba
+				/obj/item/ammo_casing, //Eat the brass you little rhoomba
+				/obj/item/slime_extract //Make sure it's inert before you eat it
 				)
 
 var/global/list/contamination_flavors = list(

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -911,7 +911,7 @@
 					var/obj/belly/B = C.loc
 					to_chat(C.bound_mob, "<span class= 'notice'>Outside of your crystal, you can see; <B>[B.desc]</B></span>")
 					to_chat(src, "<span class='notice'>You can taste the the power of command.</span>")
-		else if(I,/obj/item/slime_extract)
+		else if(istype(I,/obj/item/slime_extract))
 			visible_message("<span class='warning'>[src] demonstrates their borderline insanity by swallowing [I] whole!</span>")
 			to_chat(src, "<span class='notice'>You can taste the flavor of tingly gelatin.</span>")
 		else

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -911,6 +911,9 @@
 					var/obj/belly/B = C.loc
 					to_chat(C.bound_mob, "<span class= 'notice'>Outside of your crystal, you can see; <B>[B.desc]</B></span>")
 					to_chat(src, "<span class='notice'>You can taste the the power of command.</span>")
+		else if(I,/obj/item/slime_extract)
+			visible_message("<span class='warning'>[src] demonstrates their borderline insanity by swallowing [I] whole!</span>")
+			to_chat(src, "<span class='notice'>You can taste the flavor of tingly gelatin.</span>")
 		else
 			to_chat(src, "<span class='notice'>You can taste the flavor of garbage. Delicious.</span>")
 		return

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -912,7 +912,7 @@
 					to_chat(C.bound_mob, "<span class= 'notice'>Outside of your crystal, you can see; <B>[B.desc]</B></span>")
 					to_chat(src, "<span class='notice'>You can taste the the power of command.</span>")
 		else if(istype(I,/obj/item/slime_extract))
-			visible_message("<span class='warning'>[src] demonstrates their borderline insanity by swallowing [I] whole!</span>")
+			visible_message("<span class='warning'>[src] demonstrates their complete lack of safety by swallowing [I] whole!</span>")
 			to_chat(src, "<span class='notice'>You can taste the flavor of tingly gelatin.</span>")
 		else
 			to_chat(src, "<span class='notice'>You can taste the flavor of garbage. Delicious.</span>")


### PR DESCRIPTION
Title says it all : Expands the trash eater perk a little by allowing the ability to eat slime extracts. Comes with a custom interaction response too.

It is **technically** safe to eat them, but you should probably only eat the inert ones.